### PR TITLE
fix: getProfileProxy of null exception

### DIFF
--- a/android/src/main/java/com/bluetooth/BluetoothService.java
+++ b/android/src/main/java/com/bluetooth/BluetoothService.java
@@ -18,21 +18,23 @@ class BluetoothService extends Thread {
     public BluetoothService(ReactApplicationContext reactContext, BluetoothAdapter bluetoothAdapter) {
         this.bluetoothAdapter = bluetoothAdapter;
         // 获取配置代理对象
-        bluetoothAdapter.getProfileProxy(reactContext, new BluetoothProfile.ServiceListener() {
-            @Override
-            public void onServiceConnected(int profile, BluetoothProfile proxy) {
-                if (profile == BluetoothProfile.A2DP) {
-                    mA2dp = (BluetoothA2dp) proxy;
+        if (bluetoothAdapter != null) {
+            bluetoothAdapter.getProfileProxy(reactContext, new BluetoothProfile.ServiceListener() {
+                @Override
+                public void onServiceConnected(int profile, BluetoothProfile proxy) {
+                    if (profile == BluetoothProfile.A2DP) {
+                        mA2dp = (BluetoothA2dp) proxy;
+                    }
                 }
-            }
 
-            @Override
-            public void onServiceDisconnected(int profile) {
-                if (profile == BluetoothProfile.A2DP) {
-                    mA2dp = null;
+                @Override
+                public void onServiceDisconnected(int profile) {
+                    if (profile == BluetoothProfile.A2DP) {
+                        mA2dp = null;
+                    }
                 }
-            }
-        }, BluetoothProfile.A2DP);
+            }, BluetoothProfile.A2DP);
+        }
     }
 
     // 连接至A2dp


### PR DESCRIPTION
I had this problem in production, this PR should fix it
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/22525900/172051493-c88ffb8a-dd5e-45d8-9cec-7edc23822dac.png">
